### PR TITLE
Fix typo in merge sort comment

### DIFF
--- a/python/merge_sort.py
+++ b/python/merge_sort.py
@@ -20,7 +20,7 @@ class MergeSort(BaseSort):
       cls.marge_sort(result_array, target_array, start, mid)
       cls.marge_sort(result_array, target_array, mid, end)
 
-    ## marge
+    ## merge
     small_index = start
     large_index = mid
     index = start


### PR DESCRIPTION
## Summary
- fix the comment spelling from `marge` to `merge` in `merge_sort.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857764ce1908330b551ec54ceff7a3b