### PR TITLE
Fix queue empty state handling

### DIFF
--- a/python/queue.py
+++ b/python/queue.py
@@ -26,6 +26,8 @@ class Queue(object):
     else:
       node = self.top
       self.top = self.top.next
+      if self.top is None:
+        self.last = None
       return node.value
 
 


### PR DESCRIPTION
## Summary
- ensure Queue.last is reset when the queue becomes empty

## Testing
- `python3 python/queue.py`
- `python3 - <<'EOF'
import sys
sys.path.insert(0,'python')
from queue import Queue
q=Queue()
q.enqueue(1)
q.dequeue()
q.enqueue(2)
print(q.dequeue())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685774d280888330a5978d4bf0aedc94